### PR TITLE
RFC: support for nested usage of `iterrr:` macro and support for custom ident with `opname: ` syntax

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,15 @@ using just `it` in `mapIt` and `filterIt` is just ... and makes code a little un
 (1..10) |> reduce((a1, a2, ...), acc = 2)
 (1..10) |> each(a1, a2)
 ```
+Custom idents work with both `op:` and `op()` style syntax:
+```nim
+(1..10).items.iterrr:
+  map: n => _
+  ...
+(1..10).items.iterrr:
+  filter: (n, k) => _
+  ...
+```
 
 **example**:
 ```nim
@@ -229,6 +238,26 @@ points.items.iterrr:
   filter it > 0   # or filter(it > 0)
   each n:         # or each(n):
     echo n
+```
+
+## Nesting
+
+Both the `|>` operator and `iterrr` macro can be nested.
+
+Examples:
+
+```nim
+matrix.pairs |> map((ia, a) => (
+    a.pairs |> map((ib, _) => (ia, ib)).toseq()
+  )).toseq()
+```
+
+```nim
+matrix.pairs.iterrr:
+  map: (ia, a) => a.pairs.iterrr:
+    map: (ib, _) => (ia, ib)
+    toseq()
+  toseq()
 ```
 
 ## Debugging

--- a/src/iterrr.nim
+++ b/src/iterrr.nim
@@ -64,6 +64,8 @@ func iteratorIdents(call: NimNode): seq[NimNode] =
 
   if call[1].matchInfix "=>":
     extractIdents call[1][InfixLeftSide]
+  elif call[1].kind == nnkStmtList and matchInfix(call[1][0], "=>"):
+    extractIdents call[1][0][InfixLeftSide]
   else:
     @[]
 
@@ -91,6 +93,11 @@ func toIterrrPack(calls: seq[NimNode]): IterrrPack =
         expr =
           if matchInfix(firstParam, "=>"):
             firstParam[InfixRightSide]
+          elif firstParam.kind == nnkStmtList and matchInfix(firstParam[0], "=>"):
+            if firstParam[0].len > InfixBody:
+              newCall(firstParam[0][InfixRightSide], firstParam[0][InfixBody])
+            else:
+              firstParam[0][InfixRightSide]
           else:
             firstParam
 

--- a/src/iterrr/helpers.nim
+++ b/src/iterrr/helpers.nim
@@ -119,7 +119,7 @@ proc replaceNode*(node: NimNode, path: NodePath, by: NimNode) =
   cur[path[^1]] = by
 
 
-func findPathsImpl(node: NimNode,
+proc findPathsImpl(node: NimNode,
   fn: proc(node: NimNode): bool,
   path: NodePath,
   result: var seq[NodePath]) =
@@ -131,7 +131,7 @@ func findPathsImpl(node: NimNode,
     for i, n in node:
       findPathsImpl n, fn, path & @[i], result
 
-func findPaths*(node: NimNode,
+proc findPaths*(node: NimNode,
   fn: proc(node: NimNode): bool): seq[NodePath] {.inline.} =
 
   findPathsImpl node, fn, @[], result


### PR DESCRIPTION
Besides the fix for Nim 1.7.x the other two commits implement:

1. support for nested usage of `iterrr:` macro
2. custom ident with `opname: ` syntax

I am sure these changes can be improved but before putting more work into them if this is going in an acceptable direction. Comments?